### PR TITLE
Replace inbuilt clang flag detection with clang-flags library

### DIFF
--- a/lib/autocomplete-clang-view.coffee
+++ b/lib/autocomplete-clang-view.coffee
@@ -3,11 +3,11 @@ util = require './util'
 _ = require 'underscore-plus'
 {spawn} = require 'child_process'
 path = require 'path'
-{existsSync, readFileSync} = require 'fs'
+{existsSync} = require 'fs'
 Autocompleteview = require 'autocomplete/lib/autocomplete-view'
 snippets = require 'snippets/lib/snippets'
 {Range} = require 'atom'
-{File, Directory} = require 'pathwatcher'
+ClangFlags = require 'clang-flags'
 
 module.exports =
 class AutocompleteClangView extends Autocompleteview
@@ -88,27 +88,7 @@ class AutocompleteClangView extends Autocompleteview
     std = atom.config.get "autocomplete-clang.std.#{lang}"
     args = args.concat ["-std=#{std}"] if std
     args = args.concat ("-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths")
-    # If someone already has a .clang_complete from vim configured, use that.
-    searchDir = path.dirname @editor.getPath()
-    while searchDir.length
-        searchFilePath = path.join searchDir, ".clang_complete"
-        searchFile = new File(searchFilePath)
-        if searchFile.exists()
-            contents = ""
-            try
-                contents = readFileSync(searchFilePath, 'utf8')
-            catch error
-                console.log "autocomplete-clang couldn't read file " + searchFilePath
-                console.log error
-            contentsArray = contents.split("\n")
-            args = args.concat contentsArray
-            args = args.concat ["-working-directory=#{searchDir}"] # All the includes will be relative to the .clang_complete
-            break
-        thisDir = new Directory(searchDir)
-        if thisDir.isRoot()
-            break
-        searchDir = thisDir.getParent().getPath()
-    return args
+    args = args.concat ClangFlags.getClangFlags(atom.workspace.getActiveEditor().getPath())
 
   convertClangCompletion: (s) ->
     s = s[12..]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "underscore-plus": "1.x",
     "autocomplete": "git://github.com/atom/autocomplete.git#v0.28.0",
     "snippets": "git://github.com/atom/snippets.git#v0.43.0",
-    "pathwatcher": "^1.0"
+    "clang-flags": "^0.1.0"
   }
 }


### PR DESCRIPTION
Once I've got this merged with autocomplete-clang and atom-lint, I'm hoping to extend clang-flags to read per-file flags from the clang compdb, too.
