### PR TITLE
Use -Xclang to generate .pch and completion code instead of -cc1

### DIFF
--- a/lib/autocomplete-clang-view.coffee
+++ b/lib/autocomplete-clang-view.coffee
@@ -80,15 +80,16 @@ class AutocompleteClangView extends Autocompleteview
 
   buildClangArgs: (row, column, lang)->
     pch = [(atom.config.get "autocomplete-clang.pchFilePrefix"), lang, "pch"].join '.'
-    args = ["-cc1", "-fsyntax-only", "-x#{lang}",
-            "-code-completion-at", (["-",row+1,column+1].join ':'),
-           ]
+    args = ["-fsyntax-only", "-x#{lang}", "-Xclang"]
+    location = (["-",row+1,column+1].join ':')
+    args = args.concat ["-code-completion-at=#{location}"]
     pchPath = path.join (path.dirname @editor.getPath()), pch
     args = args.concat ["-include-pch", pch] if existsSync pchPath
     std = atom.config.get "autocomplete-clang.std.#{lang}"
     args = args.concat ["-std=#{std}"] if std
     args = args.concat ("-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths")
     args = args.concat ClangFlags.getClangFlags(atom.workspace.getActiveEditor().getPath())
+    args = args.concat ["-"]
 
   convertClangCompletion: (s) ->
     s = s[12..]

--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -135,7 +135,7 @@ module.exports =
     file = [(atom.config.get "autocomplete-clang.pchFilePrefix"), lang, "pch"].join '.'
     pch = path.join dir,file
     std = atom.config.get "autocomplete-clang.std.#{lang}"
-    args = ['-cc1', "-x#{lang}-header", '-emit-pch', '-o', pch]
+    args = ["-x#{lang}-header", "-Xclang", '-emit-pch', '-o', pch]
     args = args.concat ["-std=#{std}"] if std
     args = args.concat ("-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths")
     args = args.concat ["-"]


### PR DESCRIPTION
According to [Clang's FAQ](http://clang.llvm.org/docs/FAQ.html#i-run-clang-cc1-and-get-weird-errors-about-missing-headers), `-cc1` options are not guaranteed to be stable, and `clang -Xclang` could be a good replacement.

Furthermore, `-cc1` options can not generate completion code successfully for [cpp-netlib](http://cpp-netlib.org) header files. So, this commit is intended to fix it.
