### PR TITLE
Handle new scope names for C++, Objective-C++

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -1,7 +1,11 @@
 clangSourceScopeDictionary = {
-  'source.c++'    : 'c++' ,
+  'source.cpp'    : 'c++' ,
   'source.c'      : 'c' ,
   'source.objc'   : 'objective-c' ,
+  'source.objcpp' : 'objective-c++' ,
+
+  # For backward-compatibility with versions of Atom < 0.166
+  'source.c++'    : 'c++' ,
   'source.objc++' : 'objective-c++' ,
 }
 


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope name for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Refs atom/language-c#54.