### PR TITLE
Use the fixed clang-flags repo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "underscore-plus": "1.x",
-    "clang-flags": "git://github.com/yasuyuky/clang-flags.git"
+    "clang-flags": "git://github.com/wanderer2/clang-flags.git"
   }
 }


### PR DESCRIPTION
Hello. This package did not work in my setup (Atom 0.172 / autocomplete-clang 0.5.3) because of a few minor issues in the clang-flags package. I forked the clang-flags package and pushed my fixes upstream. Until those fixes find their way to the original clang-flags repo, please feel free to merge this change that make the autocomplete-clang package depend on the "fixed" clang-flags repo.