### PR TITLE
Use tag instead of deprecated class in keymap

### DIFF
--- a/keymaps/autocomplete-clang.cson
+++ b/keymaps/autocomplete-clang.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-/': 'autocomplete-clang:toggle'
   'cmd-ctrl-alt-e': 'autocomplete-clang:emit-pch'


### PR DESCRIPTION
Trivial change to please the "deprecation cop" warning in atom 0.175.0 

It might be necessary to increase the minimum required atom version in package.json