### PR TITLE
Fix undefined function in emit-pch 

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -15,8 +15,11 @@ module.exports =
     return @getSourceScopeLang scopes
 
   getFirstCursorScopes: (editor) ->
-    firstCursorPosition = editor.getCursors()[0].getBufferPosition()
-    scopes = editor.scopesForBufferPosition firstCursorPosition
+    if editor.getCursors
+      firstCursorPosition = editor.getCursors()[0].getBufferPosition()
+      scopes = editor.scopesForBufferPosition firstCursorPosition
+    else
+      scopes = []
 
   getSourceScopeLang: (scopes, scopeDictionary=clangSourceScopeDictionary) ->
     lang = null


### PR DESCRIPTION
Closes #32.

Apparently we cannot rely on ```editor``` providing the ```getCursors``` method. This change will result in the detected language to be ```undefined``` which in turn will make a dialog box appear saying "Error: Incompatible Language". This seems a bit better than the cryptic stacktrace.