### PR TITLE
package.json: Use tagged clang-flags instead of git URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autocomplete-clang",
   "main": "./lib/autocomplete-clang",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "autocomplete for C/C++/ObjC using clang",
   "activationEvents": [],
   "repository": "https://github.com/yasuyuky/autocomplete-clang",
@@ -12,6 +12,6 @@
   "dependencies": {
     "atom-space-pen-views": "^0.20.0",
     "underscore-plus": "1.x",
-    "clang-flags": "git://github.com/Kev/clang-flags.git"
+    "clang-flags": ">=0.2.1"
   }
 }


### PR DESCRIPTION
This should close issue #37 (and make autocomplete-clang installable in my environment)