### PR TITLE
fixes include path handling from config and adds clangArgs option for non-includepath options

### DIFF
--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -15,6 +15,11 @@ module.exports =
       default: ['.']
       items:
         type: 'string'
+    clangArgs:
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
     pchFilePrefix:
       type: 'string'
       default: '.stdafx'

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -13,7 +13,6 @@ class ClangProvider
   excludeLowerPriority: true
 
   clangCommand: "clang"
-  includePaths: [".", ".."]
 
   scopeSource:
     'source.cpp': 'c++'
@@ -96,7 +95,8 @@ class ClangProvider
     args = args.concat ["-include-pch", pchPath] if existsSync pchPath
     std = atom.config.get "autocomplete-clang.std.#{language}"
     args = args.concat ["-std=#{std}"] if std
-    args = args.concat("-I#{i}" for i in @includePaths)
+    args = args.concat("-I#{i}" for i in atom.config.get("autocomplete-clang.includePaths"))
+    args = args.concat("#{i}" for i in atom.config.get("autocomplete-clang.clangArgs"))
     args.push("-")
     args
 


### PR DESCRIPTION
For my build system I have to give some other options to Clang at the command
line like extra defines. Also it seems that the include paths in the
configuration were not being used.