### PR TITLE
Completion Snippet Update

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -78,6 +78,8 @@ class ClangProvider
         suggestion.snippet = replacement
       else
         suggestion.text = replacement
+      if suggestion.snippet
+        suggestion.snippet += ";$0"
       suggestion
 
   handleCompletionResult: (result,returnCode) ->


### PR DESCRIPTION
When tabbing through a selected autocomplete snippets the final tab now takes you
to the end of the snippet, adding a ';' at the end of the line as well.

![autocomplete-clang-snippet](https://cloud.githubusercontent.com/assets/1111348/8767261/e45fce40-2e24-11e5-921f-191da7cc0d5b.gif)

