### PR TITLE
Add support for showing brief documentation comments

### DIFF
--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -21,6 +21,12 @@ module.exports =
     ignoreClangErrors:
       type: 'boolean'
       default: true
+    includeDocumentation:
+      type: 'boolean'
+      default: true
+    includeNonDoxygenCommentsAsDocumentation:
+      type: 'boolean'
+      default: false
     "std c++":
       type: 'string'
       default: "c++11"


### PR DESCRIPTION
Adds brief/first line of doxygen comments to completion popup. Can also
parse non-doxygen comments but this seems a little buggy so disabled by
default.

Add settings to enable -code-completion-brief-comments (default on) and
-fparse-all-comments (default off)
Not included but possibly needed: clang version check (requires clang 3.2).

libclang has much better support for comments, including generating full
XML/HTML but there does not appear to be a commandline argument for this
other than an AST dump. Brief comments are a useful starting point. More
detailed support would need autocomplete-plus descriptionHTML anyway.