### PR TITLE
Add check for autocomplete-plus minimumWordLength

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -26,7 +26,7 @@ class ClangProvider
     minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength')
 
     if minimumWordLength? and lastSymbol != '.' and lastSymbol != '>'
-      return if prefix.trim().length < minimumWordLength
+      return if prefix.length < minimumWordLength
 
     if language?
       @codeCompletionAt(editor, symbolPosition.row, symbolPosition.column, language).then (suggestions) =>
@@ -123,12 +123,12 @@ LanguageUtil =
     null
 
   prefixAtPosition: (editor, bufferPosition) ->
-    regex = /[\w0-9_-]+$/ # whatever your prefix regex might be
+    regex = /\w+$/
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     line.match(regex)?[0] or ''
 
   nearestSymbolPosition: (editor, bufferPosition) ->
-    regex = /([^\w0-9_]+)[\w0-9_]*$/
+    regex = /(\W+)\w*$/
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     matches = line.match(regex)
     if matches

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -22,11 +22,11 @@ class ClangProvider
   getSuggestions: ({editor, scopeDescriptor, bufferPosition}) ->
     language = LanguageUtil.getSourceScopeLang(@scopeSource, scopeDescriptor.getScopesArray())
     prefix = LanguageUtil.prefixAtPosition(editor, bufferPosition)
-
-    minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength')
-    return if minimumWordLength and prefix.trim().length < minimumWordLength
-
     [symbolPosition,lastSymbol] = LanguageUtil.nearestSymbolPosition(editor, bufferPosition)
+    minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength')
+
+    if minimumWordLength? and lastSymbol != '.' and lastSymbol != '>'
+      return if prefix.trim().length < minimumWordLength
 
     if language?
       @codeCompletionAt(editor, symbolPosition.row, symbolPosition.column, language).then (suggestions) =>

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -22,8 +22,11 @@ class ClangProvider
   getSuggestions: ({editor, scopeDescriptor, bufferPosition}) ->
     language = LanguageUtil.getSourceScopeLang(@scopeSource, scopeDescriptor.getScopesArray())
     prefix = LanguageUtil.prefixAtPosition(editor, bufferPosition)
+
+    minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength')
+    return if minimumWordLength and prefix.trim().length < minimumWordLength
+
     [symbolPosition,lastSymbol] = LanguageUtil.nearestSymbolPosition(editor, bufferPosition)
-    return if lastSymbol == ';'
 
     if language?
       @codeCompletionAt(editor, symbolPosition.row, symbolPosition.column, language).then (suggestions) =>

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -26,7 +26,9 @@ class ClangProvider
     minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength')
 
     if minimumWordLength? and prefix.length < minimumWordLength
-      return unless LanguageUtil.afterMemberAccessOperator(editor, bufferPosition)
+      regex = /(?:\.|->|::)\s*\w*$/
+      line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+      return unless regex.test(line)
 
     if language?
       @codeCompletionAt(editor, symbolPosition.row, symbolPosition.column, language).then (suggestions) =>
@@ -137,8 +139,3 @@ LanguageUtil =
       [new Point(bufferPosition.row, symbolColumn),symbol[-1..]]
     else
       [bufferPosition,'']
-
-  afterMemberAccessOperator: (editor, bufferPosition) ->
-    regex = /(?:\.|->)\s*\w*$/
-    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
-    regex.test(line)

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -25,8 +25,8 @@ class ClangProvider
     [symbolPosition,lastSymbol] = LanguageUtil.nearestSymbolPosition(editor, bufferPosition)
     minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength')
 
-    if minimumWordLength? and lastSymbol != '.' and lastSymbol != '>'
-      return if prefix.length < minimumWordLength
+    if minimumWordLength? and prefix.length < minimumWordLength
+      return unless LanguageUtil.afterMemberAccessOperator(editor, bufferPosition)
 
     if language?
       @codeCompletionAt(editor, symbolPosition.row, symbolPosition.column, language).then (suggestions) =>
@@ -137,3 +137,8 @@ LanguageUtil =
       [new Point(bufferPosition.row, symbolColumn),symbol[-1..]]
     else
       [bufferPosition,'']
+
+  afterMemberAccessOperator: (editor, bufferPosition) ->
+    regex = /(?:\.|->)\s*\w*$/
+    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    regex.test(line)


### PR DESCRIPTION
I've changed some of the code in ClangProvider.getSuggestions, so that the Minimum Word Length setting from autocomplete-plus is taken into account. (i.e. no suggestions are shown until the minimum word length is reached.)

This should fix issue #77, and is related to some of the stuff being discussed at the end of issue #66.

(also, apologies if I've done this wrong, this is my first pull request on GitHub!)