### PR TITLE
add current directory to include path

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -100,11 +100,13 @@ class ClangProvider
       args = args.concat ["-Xclang", "-code-completion-brief-comments"]
       args.push("-fparse-all-comments") if atom.config.get("autocomplete-clang.includeNonDoxygenCommentsAsDocumentation")
 
-    pchPath = path.join(path.dirname(editor.getPath()), 'test.pch')
+    currentDir=path.dirname(editor.getPath())
+    pchPath = path.join(currentDir, 'test.pch')
     args = args.concat ["-include-pch", pchPath] if existsSync pchPath
     std = atom.config.get "autocomplete-clang.std #{language}"
     args = args.concat ["-std=#{std}"] if std
     args = args.concat ("-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths")
+    args.push("-I#{currentDir}")
     try
       clangflags = ClangFlags.getClangFlags(editor.getPath())
       args = args.concat clangflags if clangflags


### PR DESCRIPTION
Preprocessor first searches the directory that contains the source file,
(https://msdn.microsoft.com/en-us/library/36k2cdd4.aspx)
but we input the source to clang via stdin,
so we have to tell clang to add include path that contains the source file.