### PR TITLE
Add goto declaration of symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This package is currently in an experimental state.
   - default keys `[".","#","::","->"]`
 - Using `std` option like `c++11`
 - Using precompile headers for clang
+- Goto symbol definition in a source file
 
 ## Using precompiled headers
 

--- a/keymaps/autocomplete-clang.cson
+++ b/keymaps/autocomplete-clang.cson
@@ -9,4 +9,4 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-workspace':
   'cmd-ctrl-alt-e': 'autocomplete-clang:emit-pch'
-  'ctrl-i': 'autocomplete-clang:go-definition'
+  'ctrl-i': 'autocomplete-clang:go-declaration'

--- a/keymaps/autocomplete-clang.cson
+++ b/keymaps/autocomplete-clang.cson
@@ -9,3 +9,4 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-workspace':
   'cmd-ctrl-alt-e': 'autocomplete-clang:emit-pch'
+  'ctrl-i': 'autocomplete-clang:go-definition'

--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -135,9 +135,9 @@ module.exports =
     outputLines = result['output']
     t = result['term']
     baseregex = ///\w+Decl[^<]+<(?!col:)(..[^:,]+):?(\d+):?\d+?.*?col:(\d+).*?\s#{t}\s///
-    classregex = ///.*CXXRecordDecl[^<]+<([^:,]+):(\d+):(\d+).*?#{t}\ definition.*///
+    classregex = ///\w+Decl[^<]+<([^:,]+):(\d+):(\d+).*?#{t}/// #works for class and enum types
     m = outputLines.match(baseregex)
-    if m and m.length > 1 and m[1].trim() is "line"
+    if (m and m.length > 1 and m[1].trim() is "line") or m is null
       m = outputLines.match(classregex)
     if m == null
       return

--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -1,7 +1,7 @@
 util = require './util'
 {spawn} = require 'child_process'
 path = require 'path'
-{CompositeDisposable,Disposable,BufferedProcess,Selection} = require 'atom'
+{CompositeDisposable,Disposable,BufferedProcess,Selection,File} = require 'atom'
 ClangProvider = null
 defaultPrecompiled = require './defaultPrecompiled'
 
@@ -62,19 +62,19 @@ module.exports =
       'autocomplete-clang:emit-pch': =>
         @emitPch atom.workspace.getActiveTextEditor()
     @deactivationDisposables.add atom.commands.add 'atom-text-editor:not([mini])',
-      'autocomplete-clang:go-definition': => @goDefinition atom.workspace.getActiveTextEditor()
+      'autocomplete-clang:go-declaration': => @goDeclaration atom.workspace.getActiveTextEditor()
 
 
-  goDefinition: (editor)->
+  goDeclaration: (editor)->
     lang = util.getFirstCursorSourceScopeLang editor
     unless lang
-      alert "autocomplete-clang:go-defintion\nError: Incompatible Language"
+      alert "autocomplete-clang:go-declaration\nError: Incompatible Language"
       return
     command = atom.config.get "autocomplete-clang.clangCommand"
     editor.selectWordsContainingCursors();
     term = editor.getSelectedText()
     p = editor.getDirectoryPath()
-    args = @buildGoDefinitionCommandArgs(editor,lang,term)
+    args = @buildGoDeclarationCommandArgs(editor,lang,term)
     options =
       cwd: path.dirname(editor.getPath())
       input: editor.getText()
@@ -83,7 +83,7 @@ module.exports =
       stdout = (output) => allOutput.push(output)
       stderr = (output) => console.log output
       exit = (code) =>
-        resolve(@handleGoDefinitionResult({output:allOutput.join("\n"),term:term, path:p }, code))
+        resolve(@handleGoDeclarationResult({output:allOutput.join("\n"),term:term, path:p }, code))
       bufferedProcess = new BufferedProcess({command, args, options, stdout, stderr, exit})
       bufferedProcess.process.stdin.setEncoding = 'utf-8';
       bufferedProcess.process.stdin.write(editor.getText())
@@ -106,7 +106,7 @@ module.exports =
     emit_process.stdin.write headersInput
     emit_process.stdin.end()
 
-  buildGoDefinitionCommandArgs: (editor,lang,term)->
+  buildGoDeclarationCommandArgs: (editor,lang,term)->
     std = atom.config.get "autocomplete-clang.std #{lang}"
     args = ["-x#{lang}-header", "-fsyntax-only", "-Xclang", "-ast-dump", "-Xclang", "-ast-dump-filter","-Xclang" ]
     args = args.concat ["#{term}"]
@@ -129,7 +129,7 @@ module.exports =
     args = args.concat ["-"]
     return args
 
-  handleGoDefinitionResult: (result,returnCode)->
+  handleGoDeclarationResult: (result,returnCode)->
     if returnCode is not 0
         return unless atom.config.get "autocomplete-clang.ignoreClangErrors"
     outputLines = result['output']
@@ -147,8 +147,10 @@ module.exports =
     p = result['path'] + '/'
     if filematch.startsWith("./")
       filematch = p + filematch
-    if filematch != "line"
-      atom.workspace.open(filematch, {initialLine:Number(linematch)-1, initialColumn:Number(colmatch)-1})
+    f = new File filematch
+    f.exists().then (result) ->
+      if result
+        atom.workspace.open(filematch, {initialLine:Number(linematch)-1, initialColumn:Number(colmatch)-1})
 
   handleEmitPchResult: (code)->
     unless code

--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -71,8 +71,6 @@ module.exports =
       alert "autocomplete-clang:go-defintion\nError: Incompatible Language"
       return
     command = atom.config.get "autocomplete-clang.clangCommand"
-    langUtil = require("./clang-provider").LanguageUtil
-
     editor.selectWordsContainingCursors();
     term = editor.getSelectedText()
     p = editor.getDirectoryPath()
@@ -113,8 +111,8 @@ module.exports =
     args = ["-x#{lang}-header", "-fsyntax-only", "-Xclang", "-ast-dump", "-Xclang", "-ast-dump-filter","-Xclang" ]
     args = args.concat ["#{term}"]
     args = args.concat ["-std=#{std}"] if std
-    include_paths = atom.config.get "autocomplete-clang.includePaths"
-    args = args.concat (include_paths)
+    include_paths = atom.config.get("autocomplete-clang.includePaths")
+    args = args.concat ("-I#{i}" for i in include_paths)
     args = args.concat ["-"]
     return args
 
@@ -147,8 +145,10 @@ module.exports =
     linematch = m[2] if m and m.length > 2
     colmatch  = m[3] if m and m.length > 3
     p = result['path'] + '/'
+    if filematch.startsWith("./")
+      filematch = p + filematch
     if filematch != "line"
-      atom.workspace.open(p + filematch, {initialLine:Number(linematch)-1, initialColumn:Number(colmatch)-1})
+      atom.workspace.open(filematch, {initialLine:Number(linematch)-1, initialColumn:Number(colmatch)-1})
 
   handleEmitPchResult: (code)->
     unless code

--- a/menus/autocomplete-clang.cson
+++ b/menus/autocomplete-clang.cson
@@ -2,6 +2,7 @@
 'context-menu':
   'atom-text-editor':[
     {label:'Toggle autocomplete-clang', command:'autocomplete-clang:toggle'}
+    {label:'Goto Defintion', command:'autocomplete-clang:go-definition'}
   ]
 
 'menu': [

--- a/menus/autocomplete-clang.cson
+++ b/menus/autocomplete-clang.cson
@@ -2,7 +2,7 @@
 'context-menu':
   'atom-text-editor':[
     {label:'Toggle autocomplete-clang', command:'autocomplete-clang:toggle'}
-    {label:'Goto Defintion', command:'autocomplete-clang:go-definition'}
+    {label:'Goto Declaration', command:'autocomplete-clang:go-declaration'}
   ]
 
 'menu': [


### PR DESCRIPTION
This feature looks up the declaration of a symbol under cursor and opens that file in the workspace at the appropriate position in the file.