### PR TITLE
Fix 2 bugs in buildClangArgs

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -101,7 +101,7 @@ class ClangProvider
     location = "-:#{row + 1}:#{column + 1}"
     args.push "-Xclang", "-code-completion-at=#{location}"
 
-    if atom.config.get("autocomplete-clang.includeDocumentation")?
+    if atom.config.get("autocomplete-clang.includeDocumentation")
       args.push "-Xclang", "-code-completion-brief-comments"
       args.push "-fparse-all-comments" if atom.config.get("autocomplete-clang.includeNonDoxygenCommentsAsDocumentation")
 

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -96,27 +96,32 @@ class ClangProvider
     (completion for completion in completions when completion?)
 
   buildClangArgs: (editor, row, column, language) ->
-    pch = [(atom.config.get "autocomplete-clang.pchFilePrefix"), language, "pch"].join '.'
-    args = ["-fsyntax-only", "-x#{language}", "-Xclang", "-code-completion-macros"]
-    location = "-:#{row + 1}:#{column + 1}"
-    args.push "-Xclang", "-code-completion-at=#{location}"
-
-    if atom.config.get("autocomplete-clang.includeDocumentation")
-      args.push "-Xclang", "-code-completion-brief-comments"
-      args.push "-fparse-all-comments" if atom.config.get("autocomplete-clang.includeNonDoxygenCommentsAsDocumentation")
-
-    currentDir = path.dirname(editor.getPath())
-    pchPath = path.join(currentDir, 'test.pch')
-    args.push "-include-pch", pchPath if existsSync pchPath
     std = atom.config.get "autocomplete-clang.std #{language}"
+    currentDir = path.dirname(editor.getPath())
+    pchFilePrefix = atom.config.get "autocomplete-clang.pchFilePrefix"
+    pchFile = [pchFilePrefix, language, "pch"].join '.'
+    pchPath = path.join(currentDir, pchFile)
+
+    args = ["-fsyntax-only"]
+    args.push "-x#{language}"
     args.push "-std=#{std}" if std
+    args.push "-Xclang", "-code-completion-macros"
+    args.push "-Xclang", "-code-completion-at=-:#{row + 1}:#{column + 1}"
+    args.push("-include-pch", pchPath) if existsSync(pchPath)
     args.push "-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths"
     args.push "-I#{currentDir}"
+
+    if atom.config.get "autocomplete-clang.includeDocumentation"
+      args.push "-Xclang", "-code-completion-brief-comments"
+      if atom.config.get "autocomplete-clang.includeNonDoxygenCommentsAsDocumentation"
+        args.push "-fparse-all-comments"
+
     try
       clangflags = ClangFlags.getClangFlags(editor.getPath())
       args = args.concat clangflags if clangflags
     catch error
       console.log error
+
     args.push "-"
     args
 

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -95,29 +95,29 @@ class ClangProvider
     completions = (@convertCompletionLine(s) for s in outputLines)
     (completion for completion in completions when completion?)
 
-  buildClangArgs: (editor, row, column, language)->
+  buildClangArgs: (editor, row, column, language) ->
     pch = [(atom.config.get "autocomplete-clang.pchFilePrefix"), language, "pch"].join '.'
-    args = ["-fsyntax-only", "-x#{language}", "-Xclang", "-code-completion-macros", "-Xclang"]
+    args = ["-fsyntax-only", "-x#{language}", "-Xclang", "-code-completion-macros"]
     location = "-:#{row + 1}:#{column + 1}"
-    args.push("-code-completion-at=#{location}")
+    args.push "-Xclang", "-code-completion-at=#{location}"
 
     if atom.config.get("autocomplete-clang.includeDocumentation")?
-      args = args.concat ["-Xclang", "-code-completion-brief-comments"]
-      args.push("-fparse-all-comments") if atom.config.get("autocomplete-clang.includeNonDoxygenCommentsAsDocumentation")
+      args.push "-Xclang", "-code-completion-brief-comments"
+      args.push "-fparse-all-comments" if atom.config.get("autocomplete-clang.includeNonDoxygenCommentsAsDocumentation")
 
-    currentDir=path.dirname(editor.getPath())
+    currentDir = path.dirname(editor.getPath())
     pchPath = path.join(currentDir, 'test.pch')
-    args = args.concat ["-include-pch", pchPath] if existsSync pchPath
+    args.push "-include-pch", pchPath if existsSync pchPath
     std = atom.config.get "autocomplete-clang.std #{language}"
-    args = args.concat ["-std=#{std}"] if std
-    args = args.concat ("-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths")
-    args.push("-I#{currentDir}")
+    args.push "-std=#{std}" if std
+    args.push "-I#{i}" for i in atom.config.get "autocomplete-clang.includePaths"
+    args.push "-I#{currentDir}"
     try
       clangflags = ClangFlags.getClangFlags(editor.getPath())
       args = args.concat clangflags if clangflags
     catch error
       console.log error
-    args.push("-")
+    args.push "-"
     args
 
 LanguageUtil =


### PR DESCRIPTION
This should fix a couple of bugs with the `autocomplete-clang` settings. The first one is that the "Include Documentation" setting was being totally ignored. The second one is that the precompiled header being searched for was hard-coded as `test.pch`.

I found these while cleaning up the `buildClangArgs` function of `ClangProvider`.