### PR TITLE
Make changes to convertCompletionLine

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -80,7 +80,7 @@ class ClangProvider
         "${#{index}:#{arg}}"
 
       suggestion = {}
-      suggestion.rightLabel = returnType if returnType?
+      suggestion.leftLabel = returnType if returnType?
       if index > 0
         suggestion.snippet = replacement
       else

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -74,6 +74,8 @@ class ClangProvider
     [completion, comment] = completionAndComment.split commentRe
     returnTypeRe = /^\[#(.*?)#\]/
     returnType = completion.match(returnTypeRe)?[1]
+    constMemFuncRe = /\[# const#\]$/
+    isConstMemFunc = constMemFuncRe.test completion
     infoTagsRe = /\[#(.*?)#\]/g
     completion = completion.replace infoTagsRe, ''
     argumentsRe = /<#(.*?)#>/g
@@ -88,6 +90,8 @@ class ClangProvider
       suggestion.snippet = completion
     else
       suggestion.text = completion
+    if isConstMemFunc
+      suggestion.displayText = completion + ' const'
     suggestion.description = comment if comment?
     suggestion
 

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -60,7 +60,8 @@ class ClangProvider
     res
 
   lineRe: /COMPLETION: ([^:]+)(?: : (.+))?$/
-  returnTypeRe: /\[#([^#]+)#\]/ig
+  returnTypeRe: /^\[#([^#]*)#\]/
+  infoTagsRe: /\[#([^#]*)#\]/g
   argumentRe: /\<#([^#]+)#\>/ig
   commentSplitRe: /(?: : (.+))?$/
   convertCompletionLine: (s) ->
@@ -70,10 +71,8 @@ class ClangProvider
       unless pattern?
         return {snippet:completion,text:completion}
       [patternNoComment, briefComment] = pattern.split @commentSplitRe
-      returnType = null
-      patternNoType = patternNoComment.replace @returnTypeRe, (match, type) ->
-        returnType = type
-        ''
+      returnType = patternNoComment.match(@returnTypeRe)?[1]
+      patternNoType = patternNoComment.replace @infoTagsRe, ''
       index = 0
       replacement = patternNoType.replace @argumentRe, (match, arg) ->
         index++

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -59,21 +59,24 @@ class ClangProvider
         res.push(suggestion)
     res
 
-  convertCompletionLine: (s) ->
-    lineRe = /COMPLETION: ([^:]+)(?: : (.+))?$/
-    match = s.match lineRe
+  convertCompletionLine: (line) ->
+    contentRe = /^COMPLETION: (.*)/
+    match = line.match contentRe
     return unless match?
 
-    [line, basicInfo, completionAndComment] = match
-    return {text: basicInfo} unless completionAndComment?
+    [line, content] = match
+    basicInfoRe = /^(.*?) : (.*)/
+    match = content.match basicInfoRe
+    return {text: content} unless match?
 
+    [content, basicInfo, completionAndComment] = match
     commentRe = /(?: : (.*))?$/
     [completion, comment] = completionAndComment.split commentRe
-    returnTypeRe = /^\[#([^#]*)#\]/
+    returnTypeRe = /^\[#(.*?)#\]/
     returnType = completion.match(returnTypeRe)?[1]
-    infoTagsRe = /\[#([^#]*)#\]/g
+    infoTagsRe = /\[#(.*?)#\]/g
     completion = completion.replace infoTagsRe, ''
-    argumentsRe = /\<#([^#]*)#\>/g
+    argumentsRe = /<#(.*?)#>/g
     index = 0
     completion = completion.replace argumentsRe, (match, arg) ->
       index++


### PR DESCRIPTION
This does the following things:
- Adds support for `const`  C++ member functions.
- Moves return types from the right label to the left label. This is more consistent with other `autocomplete-plus` providers.
- Fixes the return types of functions sometimes appearing as `const`. (see #94)
- Fixes completion of Objective-C methods with arguments. (see #85)