### PR TITLE
Don't exclude autocomplete-plus suggestions.

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -11,7 +11,6 @@ module.exports =
 class ClangProvider
   selector: '.source.cpp, .source.c, .source.objc, .source.objcpp'
   inclusionPriority: 1
-  excludeLowerPriority: true
 
   scopeSource:
     'source.cpp': 'c++'


### PR DESCRIPTION
Fixes #93.

Suggestions from the default provider of `autocomplete-plus` will be appended to the bottom of the suggestions.