### PR TITLE
Improve regex performance.

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -91,8 +91,11 @@ class ClangProvider
     # for performance reasons.
     completionsRe = new RegExp("^COMPLETION: (" + prefix + ".*)$", "mg")
     outputLines = result.match(completionsRe)
-    completions = (@convertCompletionLine(line, prefix) for line in outputLines)
-    completions
+
+    if outputLines?
+        return (@convertCompletionLine(line, prefix) for line in outputLines)
+    else
+        return []
 
   buildClangArgs: (editor, row, column, language) ->
     std = atom.config.get "autocomplete-clang.std #{language}"


### PR DESCRIPTION
I was a bit frustrated with the autocomplete performance.  While looking into it I figured out how to use PCH's and now things are much snappier.  All the same, it would be a shame to throw away work, so here it is if you're interested.

Previous approach was to:
  -> Run multiple regexes on every clang result
  -> Filter down matches that do not match current line.

New approach is:
  -> Filter down matches that do not match current line
  -> Run multiple regexes on these matches.

In my tests, worst case senarios (single letter completes on global scope), went from ~100ms to ~10ms.  This is only a *small* performance improvement because most of the time spent in auto  completing a line is in the clang executable (for my simple cases clang was taking ~500ms to ~850ms without PCH's and ~200ms to ~450ms with PCH's).