### PR TITLE
Added the option to show system headers' documentation

### DIFF
--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -31,7 +31,7 @@ module.exports =
       default: true
     includeSystemHeadersDocumentation:
       type: 'boolean'
-      default: true
+      default: false
     includeNonDoxygenCommentsAsDocumentation:
       type: 'boolean'
       default: false

--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -29,6 +29,9 @@ module.exports =
     includeDocumentation:
       type: 'boolean'
       default: true
+    includeSystemHeadersDocumentation:
+      type: 'boolean'
+      default: true
     includeNonDoxygenCommentsAsDocumentation:
       type: 'boolean'
       default: false

--- a/lib/autocomplete-clang.coffee
+++ b/lib/autocomplete-clang.coffee
@@ -32,6 +32,7 @@ module.exports =
     includeSystemHeadersDocumentation:
       type: 'boolean'
       default: false
+      description: "**WARNING**: if there are any PCHs compiled without this option, you will have to delete them and generate them again"
     includeNonDoxygenCommentsAsDocumentation:
       type: 'boolean'
       default: false
@@ -147,6 +148,14 @@ module.exports =
     args = args.concat ["-std=#{std}"] if std
     include_paths = atom.config.get "autocomplete-clang.includePaths"
     args = args.concat ("-I#{i}" for i in include_paths)
+
+    if atom.config.get "autocomplete-clang.includeDocumentation"
+      args.push "-Xclang", "-code-completion-brief-comments"
+      if atom.config.get "autocomplete-clang.includeNonDoxygenCommentsAsDocumentation"
+        args.push "-fparse-all-comments"
+      if atom.config.get "autocomplete-clang.includeSystemHeadersDocumentation"
+        args.push "-fretain-comments-from-system-headers"
+
     args = args.concat ["-"]
     return args
 

--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -122,6 +122,8 @@ class ClangProvider
       args.push "-Xclang", "-code-completion-brief-comments"
       if atom.config.get "autocomplete-clang.includeNonDoxygenCommentsAsDocumentation"
         args.push "-fparse-all-comments"
+      if atom.config.get "autocomplete-clang.includeSystemHeadersDocumentation"
+        args.push "-fretain-comments-from-system-headers"
 
     try
       clangflags = ClangFlags.getClangFlags(editor.getPath())


### PR DESCRIPTION
Now there is the possibility to show brief documentation for standard libraries' symbols. I just added the '-fretain-comments-from-system-headers' parameter to clang when is run for code completion.