### PR TITLE
Handle C++ default/optional parameters correctly

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -78,10 +78,16 @@ class ClangProvider
     infoTagsRe = /\[#(.*?)#\]/g
     completion = completion.replace infoTagsRe, ''
     argumentsRe = /<#(.*?)#>/g
+    optionalArgumentsStart = completion.indexOf '{#'
+    completion = completion.replace /\{#/g, ''
+    completion = completion.replace /#\}/g, ''
     index = 0
-    completion = completion.replace argumentsRe, (match, arg) ->
+    completion = completion.replace argumentsRe, (match, arg, offset) ->
       index++
-      "${#{index}:#{arg}}"
+      if optionalArgumentsStart > 0 and offset > optionalArgumentsStart
+        return "${#{index}:optional #{arg}}"
+      else
+        return "${#{index}:#{arg}}"
 
     suggestion = {}
     suggestion.leftLabel = returnType if returnType?


### PR DESCRIPTION
Remove optional parameter markers "{#" and "#}"
Mark optional parameters in the autocomplete snippet

This feature relies on the fact that default arguments have to be the last arguments in the argument list. 


![bildschirmfoto 2016-06-18 um 19 51 51](https://cloud.githubusercontent.com/assets/1275898/16172780/84a36f52-358f-11e6-8f2a-1364ba0ac932.png)

![bildschirmfoto 2016-06-18 um 19 52 53](https://cloud.githubusercontent.com/assets/1275898/16172781/84abf640-358f-11e6-8a23-06f06c64d1a1.png)