### PR TITLE
fix for args length check

### DIFF
--- a/lib/clang-args-builder.coffee
+++ b/lib/clang-args-builder.coffee
@@ -13,7 +13,7 @@ module.exports =
       [outputs, errors] = [[], []]
       stdout = (data)-> outputs.push data
       stderr = (data)-> errors.push data
-      if (args.join(" ")).length > (atom.config.get "autocomplete-clang.argsCountThreshold" or 7000)
+      if (args.join(" ")).length > (atom.config.get("autocomplete-clang.argsCountThreshold") or 7000)
         [args, filePath] = makeFileBasedArgs args, editor
         console.log 'tempfile for args: '+filePath
         exit = (code)->


### PR DESCRIPTION
Not sure if this is windows specific but after further investigation with `join " "` parentheses around `" "` are optional however in `atom.config.get("autocomplete-clang.argsCountThreshold")` they seem mandatory