### PR TITLE
filtering incorrect C/CXX standards

### DIFF
--- a/lib/clang-provider.coffee
+++ b/lib/clang-provider.coffee
@@ -28,6 +28,16 @@ class ClangProvider
 
   codeCompletionAt: (editor, row, column, language, prefix) ->
     args = buildCodeCompletionArgs editor, row, column, language
+    for arg in args
+        if arg?
+            start = arg.slice(0, 6)
+            if start == '-std=c'
+                is_cxx_std = arg[6] == '+'
+                is_cxx_file = editor.getGrammar().name != 'C'
+                if is_cxx_std && !is_cxx_file
+                    args.splice(args.indexOf(arg), 1)
+                else if !is_cxx_std && is_cxx_file
+                    args.splice(args.indexOf(arg), 1)
     callback = (code, outputs, errors, resolve) =>
       console.log errors
       resolve(@handleCompletionResult(outputs, code, prefix))


### PR DESCRIPTION
In my projects, I have both C and C++ standards specified in my .clang_complete files (e.g. `-std=c99` and `-std=c++14`) but clang complains about specifying a C standard for a C++ file or the opposite. 

This PR filters the standard specifications according to the current editor's language to keep only the good ones. 

I never wrote coffeescript before so there's maybe a cleaner way to do it